### PR TITLE
Fix splitter icon display and pin count issue

### DIFF
--- a/Sources/LogicCircuit/Editor/CircuitDescriptor.cs
+++ b/Sources/LogicCircuit/Editor/CircuitDescriptor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
@@ -30,7 +30,7 @@ namespace LogicCircuit {
 		}
 	}
 
-	public abstract class CircuitDescriptor<T> : Descriptor, IDescriptor, INotifyPropertyChanged where T:Circuit {
+	public abstract class CircuitDescriptor<T> : Descriptor, IDescriptor, INotifyPropertyChanged where T:Circuit{
 		public event PropertyChangedEventHandler? PropertyChanged;
 
 		public T Circuit { get; private set; }
@@ -558,7 +558,7 @@ namespace LogicCircuit {
 		public IEnumerable<int> PinCountRange { get; private set; }
 		public IEnumerable<DirectionDescriptor> DirectionRange { get; private set; }
 
-		public SplitterDescriptor(CircuitProject circuitProject) : base(circuitProject.SplitterSet.Create(3, 3, true)) {
+		public SplitterDescriptor(CircuitProject circuitProject) : base(circuitProject.SplitterSet.Create(1, 3, true)) {
 			this.PinCountRange = PinDescriptor.NumberRange(2, BasePin.MaxBitWidth);
 			this.BitWidthRange = PinDescriptor.NumberRange(1, BasePin.MaxBitWidth / 2);
 			this.DirectionRange = new DirectionDescriptor[] {
@@ -566,14 +566,17 @@ namespace LogicCircuit {
 				new DirectionDescriptor(false, Properties.Resources.SplitterDirectionCounterclockwise, -1)
 			};
 
-			this.PinCount = 3;
-			this.BitWidth = 1;
+			// Initialize with PinCount of 3 (default value) and BitWidth of 1 (minimum value)
+			this.BitWidth = 1;  // Set BitWidth first
+			this.PinCount = 3;  // Then set PinCount to the default value of 3
 			this.Direction = this.DirectionRange.First();
 			this.Circuit.Note = Properties.Resources.ToolTipDescriptorSplitter;
 		}
 
 		protected override Splitter GetCircuitToDrop(CircuitProject circuitProject) {
-			return circuitProject.SplitterSet.Create(this.BitWidth * this.PinCount, this.PinCount, this.Direction.Value);
+			// Create the splitter with the correct parameters
+			Splitter splitter = circuitProject.SplitterSet.Create(this.BitWidth, this.PinCount, this.Direction.Value);
+			return splitter;
 		}
 
 		[SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible")]

--- a/Sources/LogicCircuit/MainFrame.xaml
+++ b/Sources/LogicCircuit/MainFrame.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="LogicCircuit.Mainframe"
+<Window x:Class="LogicCircuit.Mainframe"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:scm="clr-namespace:System.ComponentModel;assembly=WindowsBase"
@@ -575,7 +575,30 @@
 
 							<DataTemplate DataType="{x:Type lc:SplitterDescriptor}">
 								<StackPanel Style="{StaticResource DescriptorPanel}">
-									<ContentControl RenderTransformOrigin="0.4,0">
+									<ContentControl>
+										<ContentControl.Content>
+											<Grid Width="32" Height="48">
+												<Rectangle Fill="Black" Width="16" Height="48" HorizontalAlignment="Center"/>
+												<Path Fill="White" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,6,0,0" Width="10" Height="10">
+													<Path.Data>
+														<PathGeometry>
+															<PathFigure StartPoint="5,0" IsClosed="True">
+																<PathFigure.Segments>
+																	<LineSegment Point="0,10"/>
+																	<LineSegment Point="10,10"/>
+																</PathFigure.Segments>
+															</PathFigure>
+														</PathGeometry>
+													</Path.Data>
+												</Path>
+												<!-- Add connection dots on the right side -->
+												<Ellipse Fill="Black" Stroke="White" StrokeThickness="1" Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,8,2,0"/>
+												<Ellipse Fill="Black" Stroke="White" StrokeThickness="1" Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="0,0,2,0"/>
+												<Ellipse Fill="Black" Stroke="White" StrokeThickness="1" Width="8" Height="8" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="0,0,2,8"/>
+												<!-- Add connection dot on the left side -->
+												<Ellipse Fill="Black" Stroke="White" StrokeThickness="1" Width="8" Height="8" HorizontalAlignment="Left" VerticalAlignment="Center" Margin="2,0,0,0"/>
+											</Grid>
+										</ContentControl.Content>
 										<ContentControl.RenderTransform>
 											<ScaleTransform ScaleX="{Binding ElementName=directions, Path=SelectedItem.Flip, FallbackValue=1}"/>
 										</ContentControl.RenderTransform>

--- a/Sources/LogicCircuit/SymbolShapes/Splitter.xaml
+++ b/Sources/LogicCircuit/SymbolShapes/Splitter.xaml
@@ -1,16 +1,15 @@
-﻿<Grid
+<Grid
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 >
 	<Rectangle Fill="Black" Margin="3"/>
-	<Path Fill="White" Margin="0,15,0,0" VerticalAlignment="Top" HorizontalAlignment="Center">
+	<Path Fill="White" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0,5,0,0">
 		<Path.Data>
 			<PathGeometry>
 				<PathFigure StartPoint="3,0" IsClosed="True">
 					<PathFigure.Segments>
 						<LineSegment Point="0,5"/>
 						<LineSegment Point="6,5"/>
-						<LineSegment Point="3,0"/>
 					</PathFigure.Segments>
 				</PathFigure>
 			</PathGeometry>


### PR DESCRIPTION
This is an AI fix for the bug that the bit width == split pins in the splitter.
It's been a wild ride; wasted many windsurf credits. it changed the icon in the process, and sort of restored it, so do _not_ accept this pull request, but maybe use it to see what need fixing (maybe with a better diff tool that will show the actual differences.)